### PR TITLE
Use exact docassemble-cucumber during development

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bufferutil": "^4.0.1",
     "chai": "^4.2.0",
     "cucumber": "^6.0.5",
-    "docassemble-cucumber": "^0.4.42",
+    "docassemble-cucumber": "0.4.42",
     "dotenv": "^8.2.0",
     "mocha": "^7.2.0",
     "puppeteer": "^3.1.0",


### PR DESCRIPTION
While it's being developed, we want to stick with a version we know works for our repo.