### PR TITLE
Workaround changed behavior of DAFileList

### DIFF
--- a/docassemble/MAEvictionDefense/data/questions/eviction.en.yml
+++ b/docassemble/MAEvictionDefense/data/questions/eviction.en.yml
@@ -2867,10 +2867,10 @@ subquestion: |
   you can upload a picture of them now. If it's not easy to do this now,
   you can skip this step.
 fields:
-  - Upload or take a picture of any paperwork you want GBLS to review: ntq_pictures[i]
-    datatype: file
+  - Upload or take a picture of any paperwork you want GBLS to review: ntq_pictures
+    datatype: files
     required: False
-list collect: True
+#list collect: True
 ---
 id: intake facts
 question: |

--- a/docassemble/MAEvictionDefense/data/questions/eviction.yml
+++ b/docassemble/MAEvictionDefense/data/questions/eviction.yml
@@ -140,7 +140,7 @@ objects:
   - additional_tenants: DAList.using(object_type=Individual)
   - household: DAList.using(object_type=Individual)
   - incomes: IncomeList.using(there_are_any=True)
-  - ntq_pictures: DAFileList.using(there_are_any = True)
+  #- ntq_pictures: DAFileList.using(there_are_any = True)
   - landlord: Person
   - landlords_attorney: Person
   - court: MACourt
@@ -359,7 +359,7 @@ code: |
     household.gather()
     incomes.gather()
     tenant.gender
-    ntq_pictures.gather()
+    ntq_pictures
     intake_additional_information
     # view_intake
   asked_intake_questions = True


### PR DESCRIPTION
At some point, the ability to interactively edit a DAFileList with `list collect` changed. This temporarily reverts to a single upload field so that this isn't a showstopping error. It should be altered to restore the old behavior that let someone upload multiple documents whenever possible.