### PR TITLE
[codex] Run ALKiln tests on an isolated server

### DIFF
--- a/.github/workflows/run_form_tests.yml
+++ b/.github/workflows/run_form_tests.yml
@@ -10,6 +10,10 @@ on:
       tags:
         description: 'Optional. Use a "tag expression" specify which tagged tests to run. See https://cucumber.io/docs/cucumber/api/#tag-expressions for syntax.'
         default: ''
+      show_docker_output:
+        description: 'Show and save the temporary docassemble server logs. The logs may contain sensitive configuration details.'
+        default: false
+        type: boolean
   # To run your tests on a schedule, delete the first "#" symbol at the beginning of each line below.
   ## Also see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
   ## Also see https://crontab.guru/examples.html
@@ -20,13 +24,20 @@ jobs:
 
   interview-testing:
     runs-on: ubuntu-latest
-    name: Run interview tests
+    name: Run interview tests on an isolated server
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Start an isolated temporary docassemble server
+        id: github_server
+        uses: SuffolkLITLab/ALKiln/action_for_github_server@v5
+        with:
+          SHOW_DOCKER_OUTPUT: "${{ inputs.show_docker_output || false }}"
+          DOCASSEMBLECLI_VERSION: "0.0.26"
       - name: Use ALKiln to run tests
         uses: SuffolkLITLab/ALKiln@v5
         with:
-          SERVER_URL: "${{ secrets.SERVER_URL }}"
-          DOCASSEMBLE_DEVELOPER_API_KEY: "${{ secrets.DOCASSEMBLE_DEVELOPER_API_KEY }}"
-          DOCASSEMBLECLI_VERSION: "0.0.26"
+          SERVER_URL: "${{ steps.github_server.outputs.SERVER_URL }}"
+          DOCASSEMBLE_DEVELOPER_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
+          INSTALL_METHOD: "server"
+          ALKILN_TAG_EXPRESSION: "${{ inputs.tags || '' }}"
       - run: echo "Finished running ALKiln tests"

--- a/docassemble/MAEvictionDefense/connect_gsheets_data.py
+++ b/docassemble/MAEvictionDefense/connect_gsheets_data.py
@@ -2,7 +2,6 @@ import gspread
 import json
 from docassemble.base.util import get_config
 from oauth2client.service_account import ServiceAccountCredentials
-credential_info = json.loads(get_config('google').get('service account credentials'), strict=False)
 scope = ['https://spreadsheets.google.com/feeds',
          'https://www.googleapis.com/auth/drive']
 import usaddress  # type: ignore
@@ -11,6 +10,11 @@ import nameparser
 __all__ = ['read_sheet','map_address','map_name','map_attorney_info']
 
 def read_sheet(sheet_name, worksheet_title):
+  google_config = get_config('google') or {}
+  credentials = google_config.get('service account credentials')
+  if not credentials:
+    raise RuntimeError("Google service account credentials are not configured")
+  credential_info = json.loads(credentials, strict=False)
   creds = ServiceAccountCredentials.from_json_keyfile_dict(credential_info, scope)
   client = gspread.authorize(creds)
   sheet = client.open(sheet_name).worksheet(worksheet_title)

--- a/docassemble/MAEvictionDefense/data/sources/court_dates.feature
+++ b/docassemble/MAEvictionDefense/data/sources/court_dates.feature
@@ -23,6 +23,7 @@ Scenario: User's court date has passed
 @slow @4 @fault
 Scenario: User has a "fault" case with NO court date
   Given I start the interview at "eviction"
+  And the max seconds for each step is 200
   Then I get to the question id "signature" with this data:
     | var | value | trigger |
     | person_answering | tenant |  |
@@ -77,7 +78,6 @@ Scenario: User has a "fault" case with NO court date
   And I set the var "signature_choice" to "this device"
   And I sign
   And I tap to continue
-  And the max seconds for each step is 200
   Then I get to the question id "download screen" with this data:
     | var | value | trigger |
     | method_of_service | emailed |  |
@@ -89,6 +89,7 @@ Scenario: User has a "fault" case with NO court date
 @slow @5 @publichousing
 Scenario: User has a public housing voucher with a court date
   Given I start the interview at "eviction"
+  And the max seconds for each step is 200
   Then I get to the question id "signature" with this data:
     | var | value | trigger |
     | person_answering | tenant |  |
@@ -149,7 +150,6 @@ Scenario: User has a public housing voucher with a court date
   And I set the var "signature_choice" to "this device"
   And I sign
   And I tap to continue
-  And the max seconds for each step is 200
   Then I get to the question id "download screen" with this data:
     | var | value | trigger |
     | method_of_service | emailed |  |
@@ -161,6 +161,7 @@ Scenario: User has a public housing voucher with a court date
 @slow @6 @raft
 Scenario: User fell behind because of RAFT delay
   Given I start the interview at "eviction"
+  And the max seconds for each step is 200
   Then I get to the question id "signature" with this data:
     | var | value | trigger |
     | person_answering | tenant |  |
@@ -221,7 +222,6 @@ Scenario: User fell behind because of RAFT delay
   And I set the var "signature_choice" to "this device"
   And I sign
   And I tap to continue
-  And the max seconds for each step is 200
   Then I get to the question id "download screen" with this data:
     | var | value | trigger |
     | method_of_service | emailed |  |

--- a/docassemble/MAEvictionDefense/data/sources/court_dates.feature
+++ b/docassemble/MAEvictionDefense/data/sources/court_dates.feature
@@ -23,7 +23,6 @@ Scenario: User's court date has passed
 @slow @4 @fault
 Scenario: User has a "fault" case with NO court date
   Given I start the interview at "eviction"
-  And the max seconds for each step is 200
   Then I get to the question id "signature" with this data:
     | var | value | trigger |
     | person_answering | tenant |  |
@@ -60,8 +59,12 @@ Scenario: User has a "fault" case with NO court date
     | ntq_includes_tenant_name | True |  |
     | ntq_includes_all_tenants | True |  |
     | ntq_includes_correct_address | True |  |
+    | lease_requires_30_day_notice | False |  |
+    | ntq_leaves_off_required_language | False |  |
     | dont_owe_rent | True |  |
     | behind_in_rent | False |  |
+    | refused_rent_increase | False |  |
+    | other.vendor_payments | False |  |
     | lease_type | fixed_term |  |
     | lease_end_date | today + 365 |  |
     | date_received_ntq | 01/01/2020 |  |
@@ -78,6 +81,7 @@ Scenario: User has a "fault" case with NO court date
   And I set the var "signature_choice" to "this device"
   And I sign
   And I tap to continue
+  And the max seconds for each step is 200
   Then I get to the question id "download screen" with this data:
     | var | value | trigger |
     | method_of_service | emailed |  |
@@ -89,7 +93,6 @@ Scenario: User has a "fault" case with NO court date
 @slow @5 @publichousing
 Scenario: User has a public housing voucher with a court date
   Given I start the interview at "eviction"
-  And the max seconds for each step is 200
   Then I get to the question id "signature" with this data:
     | var | value | trigger |
     | person_answering | tenant |  |
@@ -150,6 +153,7 @@ Scenario: User has a public housing voucher with a court date
   And I set the var "signature_choice" to "this device"
   And I sign
   And I tap to continue
+  And the max seconds for each step is 200
   Then I get to the question id "download screen" with this data:
     | var | value | trigger |
     | method_of_service | emailed |  |
@@ -161,7 +165,6 @@ Scenario: User has a public housing voucher with a court date
 @slow @6 @raft
 Scenario: User fell behind because of RAFT delay
   Given I start the interview at "eviction"
-  And the max seconds for each step is 200
   Then I get to the question id "signature" with this data:
     | var | value | trigger |
     | person_answering | tenant |  |
@@ -222,6 +225,7 @@ Scenario: User fell behind because of RAFT delay
   And I set the var "signature_choice" to "this device"
   And I sign
   And I tap to continue
+  And the max seconds for each step is 200
   Then I get to the question id "download screen" with this data:
     | var | value | trigger |
     | method_of_service | emailed |  |

--- a/docassemble/MAEvictionDefense/data/sources/court_dates.feature
+++ b/docassemble/MAEvictionDefense/data/sources/court_dates.feature
@@ -55,16 +55,12 @@ Scenario: User has a "fault" case with NO court date
     | facts.tenant_rent_share | 1 |  |
     | facts.tenant_rent_frequency | week |  |
     | tenancy_type | lease |  |
-    | notice_type | fourteen_day |  |
+    | notice_type | thirty_day |  |
     | ntq_includes_tenant_name | True |  |
     | ntq_includes_all_tenants | True |  |
     | ntq_includes_correct_address | True |  |
     | lease_requires_30_day_notice | False |  |
     | ntq_leaves_off_required_language | False |  |
-    | dont_owe_rent | True |  |
-    | behind_in_rent | False |  |
-    | refused_rent_increase | False |  |
-    | other.vendor_payments | False |  |
     | lease_type | fixed_term |  |
     | lease_end_date | today + 365 |  |
     | date_received_ntq | 01/01/2020 |  |

--- a/docassemble/MAEvictionDefense/data/sources/court_dates.feature
+++ b/docassemble/MAEvictionDefense/data/sources/court_dates.feature
@@ -62,7 +62,7 @@ Scenario: User has a "fault" case with NO court date
     | dont_owe_rent | True |  |
     | behind_in_rent | False |  |
     | lease_type | fixed_term |  |
-    | lease_end_date | 01/01/2026 |  |
+    | lease_end_date | today + 365 |  |
     | date_received_ntq | 01/01/2020 |  |
     | date_received_summons | 02/01/2020 |  |
     | ntq_matches_summons | True |  |
@@ -205,7 +205,7 @@ Scenario: User fell behind because of RAFT delay
     | dont_owe_rent | True |  |
     | behind_in_rent | True |  |
     | lease_type | fixed_term |  |
-    | lease_end_date | 01/01/2026 |  |
+    | lease_end_date | today + 365 |  |
     | date_received_ntq | 01/01/2020 |  |
     | date_received_summons | 02/01/2020 |  |
     | ntq_matches_summons | True |  |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ dependencies = [
     "docassemble.MACourts>=0.59.4",
     "docassemble.PovertyScale>=2026.0.0",
     "docassemble.income>=0.0.36",
+    "gspread",
     "nameparser>=1.1.3",
+    "oauth2client",
+    "usaddress",
 ]
 license = { text = "MIT" }
 


### PR DESCRIPTION
## Summary

- start a fresh temporary docassemble server inside the GitHub Actions runner
- pass the temporary server URL and API key to ALKiln
- install and test the package directly on that isolated server
- retain the `docassemblecli` 0.0.26 pin and manual tag filtering
- add an opt-in workflow input for temporary server logs
- declare the Google Sheets dependencies that were previously available only on the persistent server
- defer loading optional Google credentials until the sheet integration is used
- use relative future lease dates so ALKiln scenarios do not expire over time
- align the fault scenario with a fault-appropriate 30-day notice

## Why

The previous workflow ran ALKiln against a persistent external docassemble server using `SERVER_URL` and `DOCASSEMBLE_DEVELOPER_API_KEY` repository secrets. The isolated-server workflow avoids touching that server, removes those test-time secret dependencies, and reduces failures caused by unrelated server reloads or activity.

The first isolated run also exposed that `gspread`, `oauth2client`, and `usaddress` were undeclared package dependencies. It further showed that importing the Google Sheets helper required server-specific credentials even though the interview already treats the sheet lookup as optional. The package now installs those dependencies and can start with the default isolated-server configuration.

The next run exposed a hard-coded `01/01/2026` lease end date that had become stale. The affected scenarios now use ALKiln's supported `today + 365` syntax.

The clean browser session also exposed contradictory fixture data: the fault-only scenario selected a 14-day nonpayment notice and then stalled in nonpayment-defense logic. It now uses a 30-day notice and no longer supplies nonpayment-only answers.

## Validation

- `git diff --check`
- parsed `.github/workflows/run_form_tests.yml` with PyYAML
- `python -m pytest -q` (12 passed)
- `python -m py_compile docassemble/MAEvictionDefense/connect_gsheets_data.py`
- compared the workflow inputs and outputs with the ALKiln v5 isolated GitHub server example and action definitions

The PR's GitHub Actions run will perform the end-to-end validation by creating the temporary server and running the interview tests.
